### PR TITLE
Fixes crash in plotting and NumPy warning

### DIFF
--- a/src/plotting.py
+++ b/src/plotting.py
@@ -38,7 +38,7 @@ def plot_forecast(data, val_data, forecast_params):
 
     ax.plot(
         test_timestamps,
-        data[future_timestamps[0] : future_timestamps[-1]],
+        data[test_timestamps],
         label='test data (snippet)',
         color='black',
     )
@@ -82,9 +82,11 @@ def plot_forecast_web_service(
 
 
 def predict_actual_dist(df, future_timestamps, forecasted_cases):
+    tmp = df.index
+    test_timestamps = tmp[(tmp >= future_timestamps[0]) & (tmp <= future_timestamps[-1])]
     warnings.filterwarnings("ignore", category=UserWarning)
     sns.distplot(forecasted_cases, label='prediction')
-    sns.distplot(df[future_timestamps[0] : future_timestamps[-1]], label='actual')
+    sns.distplot(df[test_timestamps], label='actual')
     plt.legend()
     plt.show()
 

--- a/src/predict.py
+++ b/src/predict.py
@@ -98,7 +98,7 @@ def forecast(model, data_name, data, num_forecast_steps):
         # Update the historical_data sequence
         # remove the oldest value and add the predicted value
         historical_data = np.roll(historical_data, shift=-1)
-        historical_data[-1] = predicted_value.values[0]
+        historical_data[-1] = predicted_value.values[0, 0]
 
     # Generate futute dates
     last_timestamp = data.index[-1]

--- a/tests/integration_tests/src/plotting.py
+++ b/tests/integration_tests/src/plotting.py
@@ -38,7 +38,7 @@ def plot_forecast(data, val_data, forecast_params):
 
     ax.plot(
         test_timestamps,
-        data[future_timestamps[0] : future_timestamps[-1]],
+        data[test_timestamps],
         label="test data (snippet)",
         color="black",
     )
@@ -78,9 +78,11 @@ def plot_forecast_web_service(
 
 
 def predict_actual_dist(df, future_timestamps, forecasted_cases):
+    tmp = df.index
+    test_timestamps = tmp[(tmp >= future_timestamps[0]) & (tmp <= future_timestamps[-1])]
     warnings.filterwarnings("ignore", category=UserWarning)
     sns.distplot(forecasted_cases, label="prediction")
-    sns.distplot(df[future_timestamps[0] : future_timestamps[-1]], label="actual")
+    sns.distplot(df[test_timestamps], label="actual")
     plt.legend()
     plt.show()
 


### PR DESCRIPTION
In _src/plotting.py_ line 41 crashes because the data series is not sorted 
 
`data[future_timestamps[0] : future_timestamps[-1]]`

This can be fixed by sorting the index `data = data.sort_index()` or indexing with the `test_timestamp`. I went with the latter for speed.

**DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)**
` historical_data[-1] = predicted_value.values[0]`

is triggered because  `predicted_value.values` is 2D so should be indexed as  `predicted_value.values[0, 0]`
